### PR TITLE
feat(widget): add clickUrl attribute to all links for link tracking

### DIFF
--- a/article-recommendations-widget.php
+++ b/article-recommendations-widget.php
@@ -27,6 +27,47 @@ function article_register_widget() {
 	register_widget('article_widget');
 }
 
+// ----------------------------------------------------------------
+
+add_action('wp_head', 'buffer_start');
+
+/**
+ * Manipulate the page after it has been constructed, right before it is sent to visitor's browser.
+ * https://www.php.net/manual/en/function.ob-start.php
+ *
+ * Filters the entire page HTML and using regex and preg_replace(), copy each link href
+ * into a data-vars-click-url attribute.
+ * @return void
+ */
+function buffer_start()
+{
+    if (!wp_doing_ajax()) {
+	// Hold constructed HTML to give time to manipulate it.
+        ob_start('callback');
+    }
+}
+
+add_action('wp_footer', 'buffer_end');
+
+function buffer_end()
+{
+    if (!wp_doing_ajax()) {
+        ob_end_flush();
+    }
+}
+
+function callback($buffer)
+{
+    $pattern     = '/<a([^>]*?)href=["|\'](.*?)["|\']/i';
+    $replacement = '<a${1}href="${2}" data-vars-click-url="${2}"';
+
+    $buffer = preg_replace($pattern, $replacement, $buffer);
+
+    return $buffer;
+}
+
+// ----------------------------------------------------------------
+
 class article_widget extends WP_Widget {
 
 	function __construct() {


### PR DESCRIPTION
ob_start() holds the HTML to give time for adding in all the data-vars-click-url={url} before
sending to visitor's browser.

### All Submissions:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

### Changes proposed in this Pull Request:

Adds `data-vars-click-url` to all anchor tags on WordPress pages. Link tracking on AMP WordPress isn't possible unless we have the url added as a `data-vars-*` so that it can be sent with our Snowplow custom events. 

This is more of a hack to get it done, since AMP has stated they won't fix this. See [Add AMP Vars: Click URL in AMP Analytics #10864](https://github.com/ampproject/amphtml/issues/10864). 

### HTML changes:

![image](https://user-images.githubusercontent.com/44077419/113776575-10a16300-96f8-11eb-9fba-8c6b0cef1430.png)

### Updates to AMP analytics config in WP admin

![image](https://user-images.githubusercontent.com/44077419/113776829-53633b00-96f8-11eb-840f-5a50e4b34c4b.png)

### Events fired:
This can be seen with the Snowplow Debugger chrome extension or Snowplow Inspector

![image](https://user-images.githubusercontent.com/44077419/113776992-84dc0680-96f8-11eb-8f46-d47e8b4e5599.png)

![image](https://user-images.githubusercontent.com/44077419/113777114-a6d58900-96f8-11eb-8ec6-9615bf018965.png)

## LightHouse:

![image](https://user-images.githubusercontent.com/44077419/113783422-b7d6c800-9701-11eb-8241-12bd1e66dda7.png)


### How to test the changes in this Pull Request:

1. Package plugin into zip file with `npm run package`
2. Upload plugin to a WordPress site that uses the AMP plugin. 
3. Inspect element on any page to check anchors for `data-vars-click-url={url}`
4. This can easily be seen on our [Newspack staging website](https://localnewslab.newspackstaging.com/2020/12/07/rutrum-vel-euismod-proin-vulputate-nulla-aliquam/), where it's added currently

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
