### PR TITLE
fix: check permalink return and break out loop at 5

### DIFF
--- a/article-recommendations.php
+++ b/article-recommendations.php
@@ -230,7 +230,7 @@ class article_widget extends WP_Widget {
 			$articles .= "data-vars-{$count_array[ $count - 1 ]}={$post['external_id']} ";
 
 			// Add list item to string builder
-			$list_items .= "<li><a id='{$id}_{$count}' {$article_attributes} {$href} </a>{$post_title}</li>";
+			$list_items .= "<li><a id='{$id}_{$count}' {$model_attributes} {$article_attributes} {$href} </a>{$post_title}</li>";
 
 			$count++; // increase count
 		}

--- a/article-recommendations.php
+++ b/article-recommendations.php
@@ -217,12 +217,8 @@ class article_widget extends WP_Widget {
 			$post_title = apply_filters('the_title', $title, $post_id);
 
 			// If permalink returns false, no post found. Then use wcp link.
-			if( ! get_permalink( $post_id ) ) {
-				$url = esc_url (  "https://www.washingtoncitypaper.com{$post['path']}" );
-				$href = "href={$url}";
-			} else {
-				$href = esc_url( get_permalink( $post_id ) );
-			}
+			$href = esc_url( get_permalink( $post_id ) ?? "https://www.washingtoncitypaper.com{$post['path']}" );
+
 
 			// Create the attributes for model and article recommendation
 			$model_attributes = "data-vars-model-id={$model['id']} data-vars-model-status={$model['status']} data-vars-model-type={$model['type']} ";
@@ -230,7 +226,7 @@ class article_widget extends WP_Widget {
 			$articles .= "data-vars-{$count_array[ $count - 1 ]}={$post['external_id']} ";
 
 			// Add list item to string builder
-			$list_items .= "<li><a id='{$id}_{$count}' {$model_attributes} {$article_attributes} {$href} </a>{$post_title}</li>";
+			$list_items .= "<li><a id='{$id}_{$count}' {$model_attributes} {$article_attributes} href={$href} </a>{$post_title}</li>";
 
 			$count++; // increase count
 		}

--- a/article-recommendations.php
+++ b/article-recommendations.php
@@ -187,11 +187,12 @@ class article_widget extends WP_Widget {
 		$count = 1;
 		$articles = "";
 		$list_items = "";
+		$model_attributes = "";
 		$count_array = ['one','two','three','four','five'];
 		foreach ( $results as $result ) {
 			// Limit 5 posts
 			if ( $count > 5 ) {
-				return;
+				break;
 			}
 
 			// Get score from result (Rec API)
@@ -206,18 +207,28 @@ class article_widget extends WP_Widget {
 			$model =  $result["model"];
 			$post = $result["recommended_article"];
 
- 			//$href = "href=https://www.washingtoncitypaper.com/{$rec['path']} >";
-			$post_id = $post['external_id'] ?? $post['ID']; // If Rec API result, get the 'external_id' else set to WP 'ID'
-			$title = $post['title'] ?? $post['post_title']; // If Rec API result, get the 'title' else set to WP 'post_title'
-			$post_title = apply_filters('the_title', $title, $post_id); // Display the post_title
-			$href = esc_url(get_permalink($post_id));
+			// If Rec API result, get the 'external_id' else set to WP 'ID'
+			$post_id = $post['external_id'] ?? $post['ID'];
+
+			// If Rec API result, get the 'title' else set to WP 'post_title'
+			$title = $post['title'] ?? $post['post_title'];
+
+			// Display the post_title
+			$post_title = apply_filters('the_title', $title, $post_id);
+
+			// If permalink returns false, no post found. Then use wcp link.
+			if( ! get_permalink( $post_id ) ) {
+				$href = esc_url( "https://www.washingtoncitypaper.com{$post['path']}" );
+			} else {
+				$href = esc_url( get_permalink( $post_id ) );
+			}
 
 			// Create the attributes for model and article recommendation
 			$model_attributes = "data-vars-model-id={$model['id']} data-vars-model-status={$model['status']} data-vars-model-type={$model['type']} ";
 			$article_attributes = "data-vars-article-id={$post['external_id']} data-vars-rec-id={$post['id']} data-vars-position={$count} data-vars-score={$score} ";
-
 			$articles .= "data-vars-{$count_array[ $count - 1 ]}={$post['external_id']} ";
 
+			// Add list item to string builder
 			$list_items .= "<li><a id='{$id}_{$count}' {$article_attributes} {$href} </a>{$post_title}</li>";
 
 			$count++; // increase count
@@ -248,7 +259,7 @@ class article_widget extends WP_Widget {
 		foreach ( $posts as $post ) {
 			// Limit 5 posts
 			if ( $count > 5 ) {
-				return;
+				break;
 			}
 
 			// I can probably made a whole default model object and use nullish coal to default the values to null.
@@ -281,6 +292,7 @@ class article_widget extends WP_Widget {
 
 			$count++;
 		}
+
 		return "<ul id={$id} {$model_attributes} {$articles} >{$list_items}</ul>";
 	} // end of function get_recent_posts
 

--- a/article-recommendations.php
+++ b/article-recommendations.php
@@ -217,8 +217,11 @@ class article_widget extends WP_Widget {
 			$post_title = apply_filters('the_title', $title, $post_id);
 
 			// If permalink returns false, no post found. Then use wcp link.
-			$href = esc_url( get_permalink( $post_id ) ?? "https://www.washingtoncitypaper.com{$post['path']}" );
+			$href = "https://www.washingtoncitypaper.com{$post['path']}";
 
+			if( get_permalink( $post_id ) ){
+				$href = esc_url( get_permalink( $post_id ) );
+			};
 
 			// Create the attributes for model and article recommendation
 			$model_attributes = "data-vars-model-id={$model['id']} data-vars-model-status={$model['status']} data-vars-model-type={$model['type']} ";
@@ -226,7 +229,7 @@ class article_widget extends WP_Widget {
 			$articles .= "data-vars-{$count_array[ $count - 1 ]}={$post['external_id']} ";
 
 			// Add list item to string builder
-			$list_items .= "<li><a id='{$id}_{$count}' {$model_attributes} {$article_attributes} href={$href} </a>{$post_title}</li>";
+			$list_items .= "<li><a id='{$id}_{$count}' {$model_attributes} {$article_attributes} href={$href} >{$post_title}</a></li>";
 
 			$count++; // increase count
 		}

--- a/article-recommendations.php
+++ b/article-recommendations.php
@@ -218,7 +218,8 @@ class article_widget extends WP_Widget {
 
 			// If permalink returns false, no post found. Then use wcp link.
 			if( ! get_permalink( $post_id ) ) {
-				$href = esc_url( "https://www.washingtoncitypaper.com{$post['path']}" );
+				$url = esc_url (  "https://www.washingtoncitypaper.com{$post['path']}" );
+				$href = "href={$url}";
 			} else {
 				$href = esc_url( get_permalink( $post_id ) );
 			}


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes the display of articles. The get_recommendation function needed to break rather than return when count > 5. The returned string would be empty otherwise.

![image](https://user-images.githubusercontent.com/44077419/120560364-91b36880-c3d0-11eb-9b35-a6e63c7db2e8.png)


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
