### PR TITLE
fix(query): change source_entity_id to int from string

### DIFF
--- a/article-recommendations.php
+++ b/article-recommendations.php
@@ -127,7 +127,7 @@ class article_widget extends WP_Widget {
 
 		// This is where you run the code and display the output
 		$URL = "https://article-rec-api.localnewslab.io/recs";
-		$query = "?source_entity_id='{$post_id}'&model_type={$model_type}&sort_by={$sort_by}{$exclude}";
+		$query = "?source_entity_id={$post_id}&model_type={$model_type}&sort_by={$sort_by}{$exclude}";
 		$request_url = $URL . $query;
 
 		$response = wp_remote_retrieve_body ( wp_remote_get( $request_url ) );


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes the query string which was sending the post ID as a `string` rather than a `int`, which is what the API expects


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
